### PR TITLE
ci: Fix rules for triggered job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,9 @@ trigger:update-dependencies:mender-docs-site:manual:
 update-dependencies:parent:
   extends: .update-dependencies
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "parent_pipeline"'
+    # CI_PIPELINE_SOURCE is 'pipeline' for multi-project pipelines. See:
+    # https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html#use-rules-to-control-downstream-pipeline-jobs
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
 
 update-dependencies:manual:
   extends: .update-dependencies


### PR DESCRIPTION
Amends commit 18b477237f2a6e5b44e7d86728aa010620c73d48

GitLab differentiates between "parent-child pipeline" and "multi-project pipeline" and we use the latter. See:
https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html#use-rules-to-control-downstream-pipeline-jobs