### PR TITLE
chore: Modify Dockerfile to explicitly define base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-ARG GOLANG_VERSION=1.19
 ARG MENDER_CLI_VERSION=1.9.0
 ARG MENDER_ARTIFACT_VERSION=3.9.0
 ARG MENDER_CLIENT_VERSION=3.4.0
 
-FROM golang:${GOLANG_VERSION} as cli-builder
+FROM golang:1.19 as cli-builder
 WORKDIR /go/src/github.com/mendersoftware/mender-cli
 ARG MENDER_CLI_VERSION
 RUN git clone https://github.com/mendersoftware/mender-cli.git . && \
@@ -11,7 +10,7 @@ RUN git clone https://github.com/mendersoftware/mender-cli.git . && \
     make get-deps && \
     make build
 
-FROM golang:${GOLANG_VERSION} as artifact-builder
+FROM golang:1.19 as artifact-builder
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ARG MENDER_ARTIFACT_VERSION
 RUN git clone https://github.com/mendersoftware/mender-artifact.git . && \
@@ -21,7 +20,7 @@ RUN git clone https://github.com/mendersoftware/mender-artifact.git . && \
         apt-get install -yyq $(cat deb-requirements.txt) ) && \
     make build
 
-FROM golang:${GOLANG_VERSION} as client-builder
+FROM golang:1.19 as client-builder
 WORKDIR /go/src/github.com/mendersoftware/mender
 ARG MENDER_CLIENT_VERSION
 RUN git clone https://github.com/mendersoftware/mender.git . && \


### PR DESCRIPTION
So that the dependency tracker bot can parse it correctly.