### PR TITLE
fix(docker): Change base image in docker image to docker:26-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN git clone https://github.com/mendersoftware/mender.git . && \
     git checkout $MENDER_CLIENT_VERSION && \
     DESTDIR=/install-modules-gen make install-modules-gen
 
-FROM docker:25-dind
+FROM docker:26-cli
 ARG MENDER_APP_UPDATE_MODULE_VERSION
 COPY --from=cli-builder /go/src/github.com/mendersoftware/mender-cli /usr/bin/
 COPY --from=artifact-builder /go/src/github.com/mendersoftware/mender-artifact/mender-artifact /usr/bin/

--- a/apk-requirements.txt
+++ b/apk-requirements.txt
@@ -1,1 +1,2 @@
 curl
+bash


### PR DESCRIPTION
The dind images does not have shell entrypoint and requires root privileges to start.