### PR TITLE
fix: correct typo in GitHub and Azure examples

### DIFF
--- a/examples/azure/build-and-deploy-multiple-artifacts.yml
+++ b/examples/azure/build-and-deploy-multiple-artifacts.yml
@@ -78,7 +78,7 @@ jobs:
 - job: build_mender_artifact_two
   pool:
     vmImage: ubuntu-latest
-  # conrainer with pre-installed mender-artifact and mender-cli tools
+  # container with pre-installed mender-artifact and mender-cli tools
   container: mendersoftware/mender-ci-tools:1.0.0
   steps:
   # Creates Mender Artifact

--- a/examples/azure/deploy-to-a-single-device.yml
+++ b/examples/azure/deploy-to-a-single-device.yml
@@ -40,7 +40,7 @@ resources:
 pool:
   vmImage: ubuntu-latest
 
-# conrainer with pre-installed mender-artifact and mender-cli tools
+# container with pre-installed mender-artifact and mender-cli tools
 container: mendersoftware/mender-ci-tools:1.0.0
 
 

--- a/examples/github/build-and-deploy-mender-artifact.yml
+++ b/examples/github/build-and-deploy-mender-artifact.yml
@@ -27,7 +27,7 @@ jobs:
   #
   build:
     runs-on: ubuntu-latest
-    # conrainer with pre-installed mender-artifact and mender-cli tools
+    # container with pre-installed mender-artifact and mender-cli tools
     container:
       image: mendersoftware/mender-ci-tools:1.0.0
     outputs:

--- a/examples/github/build-and-deploy-multiple-artifacts.yml
+++ b/examples/github/build-and-deploy-multiple-artifacts.yml
@@ -1,5 +1,5 @@
 #
-# The example shows how to build, upload and deploy Mender Artifacts for two different 
+# The example shows how to build, upload and deploy Mender Artifacts for two different
 # device types in paralel.
 #
 # 'MENDER_SERVER_ACCESS_TOKEN' secret is required to be set in GitHub repo settings.
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         device: ["sensor", "executive"]
-    # conrainer with pre-installed mender-artifact and mender-cli tools
+    # container with pre-installed mender-artifact and mender-cli tools
     container:
       image: mendersoftware/mender-ci-tools:1.0.0
     steps:

--- a/examples/github/deploy-to-a-single-device.yml
+++ b/examples/github/deploy-to-a-single-device.yml
@@ -24,7 +24,7 @@ jobs:
   #
   build-and-deploy:
     runs-on: ubuntu-latest
-    # conrainer with pre-installed mender-artifact and mender-cli tools
+    # container with pre-installed mender-artifact and mender-cli tools
     container:
       image: mendersoftware/mender-ci-tools:1.0.0
     steps:


### PR DESCRIPTION
Fixed a typo (conrainer -> container)

Ticket: None

Signed-off-by: Dennis Keller <dk.denniskeller@gmail.com>