### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/examples/azure/build-and-deploy-mender-artifact.yml
+++ b/examples/azure/build-and-deploy-mender-artifact.yml
@@ -56,7 +56,7 @@ jobs:
       curl -O https://raw.githubusercontent.com/mendersoftware/mender-ci-workflows/master/examples/hello-mender.py
       chmod 755 hello-mender.py
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACT_NAME} \
         -n ${MENDER_RELEASE_NAME} \
         --software-name hello-mender \

--- a/examples/azure/build-and-deploy-multiple-artifacts.yml
+++ b/examples/azure/build-and-deploy-multiple-artifacts.yml
@@ -60,7 +60,7 @@ jobs:
       curl -O https://raw.githubusercontent.com/mendersoftware/mender-ci-workflows/master/examples/hello-mender.py
       chmod 755 hello-mender.py
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACT_NAME_ONE} \
         -n ${MENDER_RELEASE_NAME_ONE} \
         --software-name hello-mender \
@@ -90,7 +90,7 @@ jobs:
       curl -O https://raw.githubusercontent.com/mendersoftware/mender-ci-workflows/master/examples/hello-mender.py
       chmod 755 hello-mender.py
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACT_NAME_TWO} \
         -n ${MENDER_RELEASE_NAME_TWO} \
         --software-name hello-mender \

--- a/examples/azure/deploy-to-a-single-device.yml
+++ b/examples/azure/deploy-to-a-single-device.yml
@@ -54,7 +54,7 @@ steps:
     curl -O https://raw.githubusercontent.com/mendersoftware/mender-ci-workflows/master/examples/hello-mender.py
     chmod 755 hello-mender.py
     single-file-artifact-gen \
-      --device-type raspberrypi4 \
+      --compatible-types raspberrypi4 \
       -o ${MENDER_ARTIFACT_NAME} \
       -n ${MENDER_RELEASE_NAME} \
       --software-name hello-mender \

--- a/examples/github/build-and-deploy-mender-artifact.yml
+++ b/examples/github/build-and-deploy-mender-artifact.yml
@@ -90,7 +90,7 @@ jobs:
           chmod 755 hello-mender.py
           MENDER_ARTIFACT_NAME=artifact_${MENDER_RELEASE_NAME}.mender
           single-file-artifact-gen \
-            --device-type raspberrypi4 \
+            --compatible-types raspberrypi4 \
             -o ${MENDER_ARTIFACTS_CI_ARTIFACT_PATH}/${MENDER_ARTIFACT_NAME} \
             -n ${MENDER_RELEASE_NAME} \
             --software-name hello-mender \

--- a/examples/github/build-and-deploy-multiple-artifacts.yml
+++ b/examples/github/build-and-deploy-multiple-artifacts.yml
@@ -62,7 +62,7 @@ jobs:
           SOFTWARE_NAME=${{ matrix.device }}
           SOFTWARE_VERSION="$(($RANDOM%9+1)).$(($RANDOM%9+1))"
           single-file-artifact-gen \
-            --device-type raspberrypi4 \
+            --compatible-types raspberrypi4 \
             -o ${MENDER_ARTIFACT_NAME} \
             -n ${MENDER_RELEASE_NAME} \
             --software-name ${SOFTWARE_NAME} \

--- a/examples/github/deploy-to-a-single-device.yml
+++ b/examples/github/deploy-to-a-single-device.yml
@@ -41,7 +41,7 @@ jobs:
           curl -O https://raw.githubusercontent.com/mendersoftware/mender-ci-workflows/master/examples/hello-mender.py
           chmod 755 hello-mender.py
           single-file-artifact-gen \
-            --device-type raspberrypi4 \
+            --compatible-types raspberrypi4 \
             -o ${MENDER_ARTIFACT_NAME} \
             -n ${MENDER_RELEASE_NAME} \
             --software-name hello-mender \

--- a/examples/gitlab/build-and-deploy-mender-artifact.gitlab-ci.yml
+++ b/examples/gitlab/build-and-deploy-mender-artifact.gitlab-ci.yml
@@ -40,7 +40,7 @@ mender:build:artifact:
     - chmod 755 hello-mender.py
     - |
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACTS_FOLDER}/${MENDER_ARTIFACT_NAME} \
         -n ${MENDER_RELEASE_NAME} \
         --software-name hello-mender \

--- a/examples/gitlab/build-two-artifacts.gitlab-ci.yml
+++ b/examples/gitlab/build-two-artifacts.gitlab-ci.yml
@@ -41,7 +41,7 @@ mender:build:artifact:one:
     - chmod 755 hello-mender.py
     - |
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACTS_FOLDER}/${MENDER_ARTIFACT_NAME_ONE} \
         -n ${MENDER_RELEASE_NAME_ONE} \
         --software-name hello-mender \
@@ -61,7 +61,7 @@ mender:build:artifact:two:
     - chmod 755 hello-mender.py
     - |
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACTS_FOLDER}/${MENDER_ARTIFACT_NAME_TWO} \
         -n ${MENDER_RELEASE_NAME_TWO} \
         --software-name hello-mender \

--- a/examples/gitlab/deploy-to-a-single-device.gitlab-ci.yml
+++ b/examples/gitlab/deploy-to-a-single-device.gitlab-ci.yml
@@ -41,7 +41,7 @@ mender:build:artifact:
     - chmod 755 hello-mender.py
     - |
       single-file-artifact-gen \
-        --device-type raspberrypi4 \
+        --compatible-types raspberrypi4 \
         -o ${MENDER_ARTIFACTS_FOLDER}/${MENDER_ARTIFACT_NAME} \
         -n ${MENDER_RELEASE_NAME} \
         --software-name hello-mender \


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344